### PR TITLE
Use Custom actions/unpinned-tag CodeQL Rule More lenient on SHA Pinning for Internal Workflows.

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,13 +4,9 @@ disable-default-queries: false
 
 queries:
   - uses: security-extended  # keep the full default pack
+  - uses: ./.github/codeql/queries  # custom queries
 
 query-filters:
   # Exclude the built-in unpinned-tag rule — our custom one replaces it
   - exclude:
       id: actions/unpinned-tag
-
-  # Include our custom version
-  - include:
-      id: actions/unpinned-tag
-      query: .github/codeql/queries/unpinned-tag-custom.ql

--- a/.github/codeql/queries/unpinned-tag-custom.ql
+++ b/.github/codeql/queries/unpinned-tag-custom.ql
@@ -6,7 +6,7 @@
  * @problem.severity warning
  * @security-severity 6.5
  * @precision medium
- * @id actions/unpinned-tag
+ * @id victory-live/unpinned-tag
  * @tags actions security external/cwe/cwe-829
  */
 
@@ -14,9 +14,8 @@ import actions
 
 from UsesStep step
 where
-  // Has a ref that looks like a version tag (v1, v1.2, etc.) not a SHA
-  step.getRef().regexpMatch("v\\d+.*")
-  // Is not pinned to a full commit SHA (40 hex chars)
+  // Has a ref but is not pinned to a full commit SHA (40 hex chars)
+  exists(step.getRef())
   and not step.getRef().regexpMatch("[0-9a-f]{40}")
   // Exclude internal victory-live org actions
   and not step.getCallee().matches("victory-live/%")

--- a/.github/codeql/queries/unpinned-tag-custom.ql
+++ b/.github/codeql/queries/unpinned-tag-custom.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Unpinned tag for a non-immutable Action
+ * @description Flags workflow steps using mutable version tags instead of
+ *              pinned commit SHAs, excluding trusted internal victory-live actions.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 6.5
+ * @precision medium
+ * @id actions/unpinned-tag
+ * @tags actions security external/cwe/cwe-829
+ */
+
+import actions
+
+from UsesStep step
+where
+  // Has a ref that looks like a version tag (v1, v1.2, etc.) not a SHA
+  step.getRef().regexpMatch("v\\d+.*")
+  // Is not pinned to a full commit SHA (40 hex chars)
+  and not step.getRef().regexpMatch("[0-9a-f]{40}")
+  // Exclude internal victory-live org actions
+  and not step.getCallee().matches("victory-live/%")
+select step,
+  "Unpinned tag '" + step.getRef() + "' used in step '" + step.getId() + "'. Pin to a full commit SHA instead."

--- a/codeql/codeql-config.yml
+++ b/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: "VictoryLive CodeQL Config"
+
+disable-default-queries: false
+
+queries:
+  - uses: security-extended  # keep the full default pack
+
+query-filters:
+  # Exclude the built-in unpinned-tag rule — our custom one replaces it
+  - exclude:
+      id: actions/unpinned-tag
+
+  # Include our custom version
+  - include:
+      id: actions/unpinned-tag
+      query: .github/codeql/queries/unpinned-tag-custom.ql


### PR DESCRIPTION
## Summary

Replaces the default `actions/unpinned-tag` CodeQL rule with a custom query that excludes internal `victory-live/*` actions from the check.

GitHub Advanced Security flags workflow steps that pin to a version tag (e.g. `v1`) rather than a full commit SHA. This is appropriate for third-party actions but produces false positives for our own internal composite actions in `victory-live/ci-workflows`, where `v1`-style tags are controlled and trusted.

## Changes

- `.github/codeql/queries/unpinned-tag-custom.ql` — custom CodeQL query that replicates the default `actions/unpinned-tag` rule but excludes any `uses` step referencing `victory-live/*`
- `.github/codeql/codeql-config.yml` — CodeQL config that disables the built-in `actions/unpinned-tag` rule and substitutes the custom query above; applied org-wide via default setup

## Why not dismiss the alert?

Auto-dismissal would suppress the alert after the fact and still generate noise in the security dashboard. Replacing the query at the source produces no alert at all for internal actions, which better reflects the actual risk posture.

## Testing

- [ ] Verify the custom query compiles without errors in the CodeQL CLI (`codeql query compile`)
- [ ] Trigger a default-setup scan on a repo that uses `victory-live/ci-workflows` and confirm no alert fires for internal composite actions
- [ ] Trigger a scan on a repo that uses an unpinned third-party action and confirm the alert still fires
- [ ] Confirm org-level default setup is pointed at this config file

## References

- Alert that prompted this: `actions/unpinned-tag` firing on `victory-live/ci-workflows/.github/composite-actions/helm-charts-filter-substantive` with ref `v1`
- [CodeQL actions library — UsesStep](https://github.com/github/codeql)
- [GitHub docs — CodeQL config for default setup](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning)